### PR TITLE
Feature/extend view and view model test support

### DIFF
--- a/Source/CelestialMapper.UI.Test/Features/Map/MapViewTest.cs
+++ b/Source/CelestialMapper.UI.Test/Features/Map/MapViewTest.cs
@@ -1,13 +1,23 @@
 ﻿using CelestialMapper.ViewModel;
+using Moq;
 
 namespace CelestialMapper.UI.Test;
 
 [TestFixture]
-[Ignore("Need to find a solution how to mock the resource service (CelestialMap UserControl uses one)")]
+//[Ignore("Need to find a solution how to mock the resource service (CelestialMap UserControl uses one)")]
 public class MapViewTest : FeatureViewTest<MapView, MapViewModel>
 {
     public override string DefaultFeatureName => "Map";
 
     public override Func<IServiceProvider, MapView> FeatureViewFactory
-        => s => new MapView();
+        => s => new MapView(ServiceProvider.Object, false);
+
+    public override void OneTimeSetUp()
+    {
+        base.OneTimeSetUp();
+
+        ResourceResolver
+            .Setup(x => x.ResolveResource("Double.Map.Diameter"))
+            .Returns(100);
+    }
 }

--- a/Source/CelestialMapper.UI.Test/TestUtils/FeatureViewTest.cs
+++ b/Source/CelestialMapper.UI.Test/TestUtils/FeatureViewTest.cs
@@ -14,6 +14,8 @@ public abstract class FeatureViewTest<TFeatureView, TViewModel>
 
     public Mock<IServiceProvider> ServiceProvider { get; } = new(MockBehavior.Strict);
 
+    public Mock<IResourceResolver> ResourceResolver { get; } = new(MockBehavior.Strict);
+
     #endregion
 
     #region FeatureViewBase
@@ -34,7 +36,7 @@ public abstract class FeatureViewTest<TFeatureView, TViewModel>
 
         ServiceProvider
             .Setup(x => x.GetService(typeof(IResourceResolver)))
-            .Returns(Mock.Of<IResourceResolver>());
+            .Returns(ResourceResolver.Object);
     }
 
     #endregion

--- a/Source/CelestialMapper.UI.Test/TestUtils/FeatureViewTest.cs
+++ b/Source/CelestialMapper.UI.Test/TestUtils/FeatureViewTest.cs
@@ -31,6 +31,10 @@ public abstract class FeatureViewTest<TFeatureView, TViewModel>
         ServiceProvider
             .Setup(x => x.GetService(ViewModelType))
             .Returns(Mock.Of<IViewModel>());
+
+        ServiceProvider
+            .Setup(x => x.GetService(typeof(IResourceResolver)))
+            .Returns(Mock.Of<IResourceResolver>());
     }
 
     #endregion

--- a/Source/CelestialMapper.UI.Test/ViewSupport/Controls/FeatureViewBaseTest.cs
+++ b/Source/CelestialMapper.UI.Test/ViewSupport/Controls/FeatureViewBaseTest.cs
@@ -7,7 +7,7 @@ class MockFeatureViewBase : FeatureViewBase
 {
 
     public MockFeatureViewBase(IServiceProvider serviceProvider)
-        : base(serviceProvider)
+        : base(serviceProvider, false)
     {
     }
 

--- a/Source/CelestialMapper.UI/Features/Map/MapView.xaml.cs
+++ b/Source/CelestialMapper.UI/Features/Map/MapView.xaml.cs
@@ -11,9 +11,14 @@ public partial class MapView : FeatureViewBase
         InitializeComponent();
     }
 
-    public MapView(IServiceProvider serviceProvider)
-        : base(serviceProvider)
+    public MapView(IServiceProvider serviceProvider, bool allowInitializeComponent = true)
+        : base(serviceProvider, allowInitializeComponent)
     {
+        if (!AllowInitializeComponent)
+        {
+            return;
+        }
+
         InitializeComponent();
     }
 

--- a/Source/CelestialMapper.UI/Resources/ResourceResolver.cs
+++ b/Source/CelestialMapper.UI/Resources/ResourceResolver.cs
@@ -9,7 +9,7 @@ public class ResourceResolver : IResourceResolver
 
         if (resource is null)
         {
-            throw new InvalidOperationException($"Resource of {key} not found");
+            throw GetInvalidOperationException(key);
         }
 
         return resource;
@@ -28,5 +28,20 @@ public class ResourceResolver : IResourceResolver
             return false;
         }
     }
+
+    public object ResolveResource(string key)
+    {
+        var resource = App.Current.Resources[key];
+
+        if (resource is null)
+        {
+            throw GetInvalidOperationException(key);
+        }
+
+        return resource;
+    }
+
+    private static InvalidOperationException GetInvalidOperationException(string key)
+        => new InvalidOperationException($"Resource of {key} not found");
 
 }

--- a/Source/CelestialMapper.UI/ViewSupport/Controls/CelestialMap/CelestialMap.xaml
+++ b/Source/CelestialMapper.UI/ViewSupport/Controls/CelestialMap/CelestialMap.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+﻿<local:PlatformUserControl
     x:Class="CelestialMapper.UI.CelestialMap"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -50,4 +50,4 @@
             VerticalAlignment="Center" />
 
     </Grid>
-</UserControl>
+</local:PlatformUserControl>

--- a/Source/CelestialMapper.UI/ViewSupport/Controls/CelestialMap/CelestialMap.xaml.cs
+++ b/Source/CelestialMapper.UI/ViewSupport/Controls/CelestialMap/CelestialMap.xaml.cs
@@ -10,7 +10,7 @@ using static CelestialMapper.UI.DependencyPropertyHelper;
 /// <summary>
 /// Interaction logic for CelestialMap.xaml
 /// </summary>
-public partial class CelestialMap : UserControl
+public partial class CelestialMap : PlatformUserControl
 {
 
     #region Fields
@@ -27,7 +27,7 @@ public partial class CelestialMap : UserControl
 
     #region Properties
 
-    public double Diameter => (double)FindResource("Double.Map.Diameter");
+    public double Diameter => (double)GetResource("Double.Map.Diameter");
 
     #endregion
 

--- a/Source/CelestialMapper.UI/ViewSupport/Controls/PlatformUserControl.cs
+++ b/Source/CelestialMapper.UI/ViewSupport/Controls/PlatformUserControl.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace CelestialMapper.UI;
+
+public class PlatformUserControl : UserControl
+{
+    protected IResourceResolver resourceResolver;
+
+    public PlatformUserControl()
+    {
+        ServiceProvider = App.ServiceProvider;
+        this.resourceResolver = GetResourceResolver();
+    }
+
+    public PlatformUserControl(IServiceProvider serviceProvider)
+    {
+        ServiceProvider = serviceProvider;
+        this.resourceResolver = GetResourceResolver();
+            
+    }
+
+    protected IServiceProvider ServiceProvider { get; }
+
+    protected object GetResource(string key)
+        => this.resourceResolver.ResolveResource(key);
+
+    private IResourceResolver GetResourceResolver()
+    {
+        return ServiceProvider.GetService<IResourceResolver>()
+            ?? throw new InvalidOperationException("Could not find IResourceResolver service");
+    }
+
+}

--- a/Source/CelestialMapper.UI/ViewSupport/Controls/PlatformUserControl.cs
+++ b/Source/CelestialMapper.UI/ViewSupport/Controls/PlatformUserControl.cs
@@ -16,7 +16,6 @@ public class PlatformUserControl : UserControl
     {
         ServiceProvider = serviceProvider;
         this.resourceResolver = GetResourceResolver();
-            
     }
 
     protected IServiceProvider ServiceProvider { get; }

--- a/Source/CelestialMapper.UI/ViewSupport/FeatureViewBase.cs
+++ b/Source/CelestialMapper.UI/ViewSupport/FeatureViewBase.cs
@@ -2,20 +2,18 @@
 
 using static CelestialMapper.UI.DependencyPropertyHelper;
 
-public abstract class FeatureViewBase : UserControl
+public abstract class FeatureViewBase : PlatformUserControl
 {
 
     public FeatureViewBase()
+        : base()
     {
-        ServiceProvider = App.ServiceProvider;
     }
 
     public FeatureViewBase(IServiceProvider serviceProvider)
+        : base(serviceProvider)
     {
-        ServiceProvider = serviceProvider;
     }
-
-    protected IServiceProvider ServiceProvider { get; }
 
     protected abstract Type ViewModelType { get; }
 

--- a/Source/CelestialMapper.UI/ViewSupport/FeatureViewBase.cs
+++ b/Source/CelestialMapper.UI/ViewSupport/FeatureViewBase.cs
@@ -10,10 +10,13 @@ public abstract class FeatureViewBase : PlatformUserControl
     {
     }
 
-    public FeatureViewBase(IServiceProvider serviceProvider)
+    public FeatureViewBase(IServiceProvider serviceProvider, bool allowInitializeComponent = true)
         : base(serviceProvider)
     {
+        AllowInitializeComponent = allowInitializeComponent;
     }
+
+    internal bool AllowInitializeComponent { get; }
 
     protected abstract Type ViewModelType { get; }
 

--- a/Source/CelestialMapper.ViewModel.Test/Features/Map/MapViewModelTest.cs
+++ b/Source/CelestialMapper.ViewModel.Test/Features/Map/MapViewModelTest.cs
@@ -7,22 +7,20 @@ using PracticalAstronomy.CSharp;
 namespace CelestialMapper.ViewModel.Test;
 
 [TestFixture]
-public class MapViewModelTest : TestBase<MapViewModel>
+public class MapViewModelTest : ViewModelTest<MapViewModel>
 {
 
-    public Mock<IViewModelSupport> ViewModelSupport { get; set; } = new();
     public Mock<IMapManager> MapManager { get; set; } = new();
 
     public override Func<MapViewModel> CreateSUT => () => new MapViewModel(MapManager.Object, ViewModelSupport.Object);
+
+    public override string DefaultFeatureName => "Map";
 
     #region SetUp
 
     [SetUp]
     public void SetUp()
     {
-        ViewModelSupport = new Mock<IViewModelSupport>(MockBehavior.Strict);
-        ViewModelSupport.SetupGet(x => x.ResourceResolver).Returns(new Mock<IResourceResolver>().Object);
-
         MapManager = new Mock<IMapManager>(MockBehavior.Strict);
     }
 
@@ -33,11 +31,8 @@ public class MapViewModelTest : TestBase<MapViewModel>
     [Test]
     public void Initialize_InitializeGenerateMapCommand_GenerateMapCommandIsNotNull()
     {
-        // Arrange
-        var sut = CreateSUT();
-
-        // Act
-        sut.Initialize(IViewModelConfigurator.Create("Map"));
+        // Arrange & Act
+        var sut = CreateSUTAndInitialize();
 
         // Assert
         Assert.That(sut.GenerateMapCommand, Is.Not.Null);
@@ -58,9 +53,8 @@ public class MapViewModelTest : TestBase<MapViewModel>
         MapManager
             .Setup(x => x.Generate(It.IsAny<Geographic>(), It.IsAny<DateTime>(), It.IsAny<IGenerateMapSettings>()))
             .Returns(Task.FromResult(map));
-        
-        var sut = CreateSUT();
-        sut.Initialize(IViewModelConfigurator.Create("Map"));
+
+        var sut = CreateSUTAndInitialize();
 
         // Act
         sut.GenerateMapCommand!.Execute(null);

--- a/Source/CelestialMapper.ViewModel.Test/Features/Shell/ShellViewModelTest.cs
+++ b/Source/CelestialMapper.ViewModel.Test/Features/Shell/ShellViewModelTest.cs
@@ -1,38 +1,14 @@
-﻿using CelestialMapper.TestUtilities;
-using Moq;
-
-namespace CelestialMapper.ViewModel.Test;
+﻿namespace CelestialMapper.ViewModel.Test;
 
 [TestFixture]
-public class ShellViewModelTest : TestBase<ShellViewModel>
+public class ShellViewModelTest : ViewModelTest<ShellViewModel>
 {
 
     #region SetUp
 
-    public Mock<IViewModelSupport> ViewModelSupport { get; private set; } = new();
-
     public override Func<ShellViewModel> CreateSUT => () => new ShellViewModel(ViewModelSupport.Object);
 
-    [SetUp]
-    public void SetUp()
-    {
-        ViewModelSupport = new Mock<IViewModelSupport>(MockBehavior.Strict);
-        ViewModelSupport.SetupGet(x => x.ResourceResolver).Returns(new Mock<IResourceResolver>().Object);
-    }
-
-    #endregion
-
-    #region Tests
-
-    [Test]
-    public void Initialize_Passes()
-    {
-        CreateSUT().Initialize(new GenericViewModelConfigurator()
-        {
-            GetFeatureNameFunc = () => "Shell",
-            GetSubViewModelsFunc = () => Enumerable.Empty<IViewModel>()
-        });
-    }
+    public override string DefaultFeatureName => "Shell";
 
     #endregion
 

--- a/Source/CelestialMapper.ViewModel.Test/TestUtils/ViewModelTest.cs
+++ b/Source/CelestialMapper.ViewModel.Test/TestUtils/ViewModelTest.cs
@@ -1,0 +1,83 @@
+﻿using Moq;
+
+namespace CelestialMapper.ViewModel.Test;
+
+public abstract class ViewModelTest<TViewModel>
+    where TViewModel : class, IViewModel
+{
+
+    public abstract Func<TViewModel> CreateSUT { get; }
+
+    public abstract string DefaultFeatureName { get; }
+
+    public virtual IViewModelConfigurator DefaultViewModelConfigurator 
+        => IViewModelConfigurator.Create(DefaultFeatureName);
+
+    public virtual Dictionary<string, IViewModelConfigurator> AllConfigurators
+        => new()
+        {
+            [DefaultFeatureName] = DefaultViewModelConfigurator
+        };
+
+    #region Mocks
+
+    public Mock<IViewModelSupport> ViewModelSupport { get; } = new(MockBehavior.Strict);
+
+    public Mock<IResourceResolver> ResourceResolver { get; } = new(MockBehavior.Strict);
+
+    #endregion
+
+    #region SetUp
+
+    [OneTimeSetUp]
+    public virtual void OneTimeSetUp()
+    {
+        foreach (var config in AllConfigurators)
+        {
+            var value = config.Key;
+            ResourceResolver
+                .Setup(x => x.TryResolveString($"String.FeatureName.{config.Key}", out value))
+                .Returns(true);
+        }
+
+        ViewModelSupport.SetupGet(x => x.ResourceResolver)
+            .Returns(ResourceResolver.Object);
+    }
+
+    #endregion
+
+    #region Base Tests
+
+    [Test]
+    public virtual void Initialize_AllConfigurators_Passes()
+    {
+        var sut = CreateSUT();
+
+        Assert.Multiple(() =>
+        {
+            foreach (var config in AllConfigurators)
+            {
+                sut.Initialize(config.Value);
+            }
+        });
+    }
+
+    #endregion
+
+    #region Helpers
+
+    protected TViewModel CreateSUTAndInitialize()
+    {
+        return CreateSUTAndInitialize(DefaultViewModelConfigurator);
+    }
+
+    protected TViewModel CreateSUTAndInitialize(IViewModelConfigurator viewModelConfigurator)
+    {
+        var sut = CreateSUT();
+        sut.Initialize(viewModelConfigurator);
+        return sut;
+    }
+
+    #endregion
+
+}

--- a/Source/CelestialMapper.ViewModel/ViewModelSupport/Resources/IResourceResolver.cs
+++ b/Source/CelestialMapper.ViewModel/ViewModelSupport/Resources/IResourceResolver.cs
@@ -7,4 +7,6 @@ public interface IResourceResolver
 
     public bool TryResolveString(string key, out string value);
 
+    public object ResolveResource(string key);
+
 }


### PR DESCRIPTION
- Create PlatformUserControl to separate Views from Controls so the Views now can be configured to not initialize their components which caused crashes in UI tests
- Create MapView tests
- Add base class for View Model Tests